### PR TITLE
Update index.rst for Contribute topic

### DIFF
--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -32,7 +32,7 @@ templates:
 
 If your issue does not fit into one of these categories, create your own issue.
 
-To reach the PyAnsys support team, email pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+To reach the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 
 Build documentation

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -32,7 +32,7 @@ templates:
 
 If your issue does not fit into one of these categories, create your own issue.
 
-To reach the PyAnsys support team, email `pyansys.support@ansys.com <pyansys_support_>`_.
+To reach the PyAnsys support team, email pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 
 Build documentation


### PR DESCRIPTION
In the "Build documentation" section, do we still need the information about where the doc for the latest stable versus latest development versions are located? It seems that it's more important that they know how to use the menu option for toggling between the doc for different versions.